### PR TITLE
Fixed an error where the Content-Type header on DELETE

### DIFF
--- a/lib/src/dataProvider/fetch.js
+++ b/lib/src/dataProvider/fetch.js
@@ -6,7 +6,7 @@ exports.createHeadersFromOptions = function (options) {
             Accept: 'application/json'
         })), as = Headers;
     if (!requestHeaders.has('Content-Type') &&
-        !(options && (!options.method || options.method === 'GET')) &&
+        !(options && (!options.method || options.method === 'GET' || options.method === 'DELETE')) &&
         !(options && options.body && options.body instanceof FormData)) {
         requestHeaders.set('Content-Type', 'application/json');
     }


### PR DESCRIPTION
Fixed an error where the Content-Type header was added to a DELETE request. The Fastify server returns an error when receiving an empty body and a Content-Type header.